### PR TITLE
Fix compilation errors under Linux

### DIFF
--- a/booot7.dpr
+++ b/booot7.dpr
@@ -14,8 +14,9 @@ uses
   {$ifdef UNIX}
   cthreads,
   {$endif }
+  SysUtils,
   {$ifdef WIN64}
-  windows,SysUtils,
+  windows,
   {$endif }
   uBitBoards in 'uBitBoards.pas',
   uMagic in 'uMagic.pas',
@@ -29,8 +30,8 @@ uses
   uSort in 'uSort.pas',
   uUci in 'uUci.pas',
   uKPK in 'uKPK.pas',
-  Unn in 'Unn.pas',
-  Ubenchmark in 'Ubenchmark.pas';
+  uNN in 'uNN.pas',
+  uBenchmark in 'uBenchmark.pas';
 
 Procedure EngineInit;
 // Инициализация движка сразу после старта
@@ -100,6 +101,6 @@ begin
   //checkbinary(0,'1data.bin',100000);
   //checkbinary(0,'2data.bin',100000);
   //checkbinary(0,'3data.bin',100000);
-  
+
   MainLoop;
 end.

--- a/booot7.lpi
+++ b/booot7.lpi
@@ -84,7 +84,7 @@
         <IsPartOfProject Value="True"/>
       </Unit>
       <Unit>
-        <Filename Value="Unn.pas"/>
+        <Filename Value="uNN.pas"/>
         <IsPartOfProject Value="True"/>
       </Unit>
       <Unit>
@@ -96,6 +96,9 @@
   <CompilerOptions>
     <Version Value="11"/>
     <PathDelim Value="\"/>
+    <Target>
+      <Filename Value="booot7"/>
+    </Target>
     <SearchPaths>
       <IncludeFiles Value="$(ProjOutDir)"/>
       <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>

--- a/uAttacks.pas
+++ b/uAttacks.pas
@@ -27,7 +27,7 @@ Function isLegal(move:integer;Pinned:TBitBoard; var Board:TBoard):boolean;
 Function isPseudoCorrect(move:integer;var Board:TBoard):boolean;
 Function GoodSee(move:integer;var Board:TBoard;margin:integer):boolean;
 implementation
- uses Unn;
+ uses uNN;
 
 Function KnightAttacksBB(sq:integer):TBitBoard;inline;
  begin

--- a/uBoard.pas
+++ b/uBoard.pas
@@ -197,7 +197,7 @@ Procedure UnMakeNullMove(var Board:TBoard;var Undo:TUndo);
 var
    rep:Trepetition;
 implementation
-uses uAttacks,DateUtils,uHash,uThread,uSort,Unn,uMagic;
+uses uAttacks,DateUtils,uHash,uThread,uSort,uNN,uMagic;
 
 Procedure ClearBoard(var Board:TBoard);
 var
@@ -1339,7 +1339,7 @@ begin
         else Piese:=-PieseTyp;
       SetPiese(MyColor,DestSq,Piese,PieseTyp,Board);
     end;
- 
+
   // откатываем основной ход
   MovePiese(MyColor,DestSq,FromSq,Piese,PieseTyp,Board);
   // Откатываем взятие

--- a/uEval.pas
+++ b/uEval.pas
@@ -5,7 +5,7 @@
 {$ENDIF}
 
 interface
-uses uBoard,Unn;
+uses uBoard,uNN;
 
 
 

--- a/uNN.pas
+++ b/uNN.pas
@@ -1,4 +1,4 @@
-﻿unit Unn;
+﻿unit uNN;
 
 {$IFDEF FPC}
   {$MODE Delphi}
@@ -164,7 +164,7 @@ Type
 var
    Nets : array[0..MaxNets-1] of  TNeuralNetWeights;
    gg,bb :integer;
-  
+
 function GetFullVersionName:ansistring;
 Function loadnet(name:shortstring;var CurrNet:TNeuralNetWeights):boolean;
 Function NetReSigma(CurrNet:PNeuralNet;y:integer):integer;
@@ -1699,7 +1699,7 @@ begin
         then FromPiese:=Pawn
         else FromPiese:=-Pawn;
     end else FromPiese:=Piese;
-  
+
   // Обновляем белый аккумулятор
   WhiteFrameStartIndex:=GetWhiteFrameIndex(Nets[NetIndex].model,Board);
   WhiteMirror:=GetWhiteKingMirror(Nets[NetIndex].model,Board);

--- a/uSearch.pas
+++ b/uSearch.pas
@@ -9,7 +9,7 @@ uses
   {$ifdef WIN64}
   windows,
   {$endif }
-uBitBoards,uBoard,uThread,uEval,uSort,uAttacks,uHash,SysUtils,DateUtils,SyncObjs,Unn;
+uBitBoards,uBoard,uThread,uEval,uSort,uAttacks,uHash,SysUtils,DateUtils,SyncObjs,uNN;
 
 Type
   Tgame = record
@@ -32,8 +32,8 @@ Type
               syzygyman : integer;
               syzygydepth : integer;
             end;
- 
- 
+
+
 Const
   doScaleEval=True;
 

--- a/uThread.pas
+++ b/uThread.pas
@@ -5,7 +5,7 @@
 {$ENDIF}
 
 interface
-uses SyncObjs,SysUtils,uBoard,uSort,Unn,uHash,Classes;
+uses SyncObjs,SysUtils,uBoard,uSort,uNN,uHash,Classes;
 Const
   MaxThreads=256;
   MaxPV=130;

--- a/uUci.pas
+++ b/uUci.pas
@@ -20,7 +20,7 @@ Procedure NewGame;
 Procedure SetRemain;
 
 implementation
-   uses uThread,Unn,Ubenchmark;
+   uses uThread,uNN,Ubenchmark;
 
 
 Procedure SetHash(var TT:TTable;size:integer);


### PR DESCRIPTION
The 7.4 release doesn't compile under Linux.
```
uAttacks.pas(30,7) Fatal: (10022) Can't find unit Unn used by uAttacks
```
```
booot7.dpr(42,20) Error: (5000) Identifier not found "inttostr"
```
This PR fixes both errors.